### PR TITLE
geofence integration fix

### DIFF
--- a/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxy.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxy.java
@@ -27,6 +27,7 @@ import org.geoserver.ows.util.OwsUtils;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geotools.factory.CommonFactoryFinder;
 import org.opengis.filter.FilterFactory;
+import org.springframework.util.ClassUtils;
 
 /**
  * Proxies an object storing any modifications to it.
@@ -533,7 +534,7 @@ public class ModificationProxy implements WrappingProxy, Serializable {
      */
     private Class getCatalogInfoInterface(Class<? extends CatalogInfo> clazz) {
         Class result = CatalogInfo.class;
-        for (Class c : clazz.getInterfaces()) {
+        for (Class c : ClassUtils.getAllInterfacesForClass(clazz)) {
             if(result.isAssignableFrom(c)) {
                 result = c;
             }

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxyCloner.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ModificationProxyCloner.java
@@ -27,6 +27,7 @@ import org.geoserver.catalog.CatalogInfo;
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.config.util.XStreamPersisterFactory;
 import org.geotools.util.logging.Logging;
+import org.springframework.util.ClassUtils;
 
 import com.thoughtworks.xstream.XStream;
 
@@ -129,7 +130,7 @@ class ModificationProxyCloner {
         Class<? extends CatalogInfo> sourceClass = object.getClass();
         Class result = CATALOGINFO_INTERFACE_CACHE.get(sourceClass);
         if(result == null) {
-            Class[] interfaces = sourceClass.getInterfaces();
+            Class[] interfaces = ClassUtils.getAllInterfacesForClass(sourceClass);
             // collect only CatalogInfo related interfaces
             List<Class> cis = new ArrayList<Class>();
             for (Class clazz : interfaces) {

--- a/src/main/src/main/java/org/geoserver/catalog/impl/ProxyUtils.java
+++ b/src/main/src/main/java/org/geoserver/catalog/impl/ProxyUtils.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.util.ClassUtils;
+
 /**
  * Utility class for working with proxies.
  * 
@@ -28,11 +30,11 @@ public class ProxyUtils {
      */
     public static <T> T createProxy(T proxyObject, Class<T> clazz, InvocationHandler h) {
         // proxy all interfaces implemented by the source object
-        List<Class> proxyInterfaces = (List) Arrays.asList( proxyObject.getClass().getInterfaces() );
+        List<Class> proxyInterfaces = Arrays.asList( ClassUtils.getAllInterfaces(proxyObject) );
         
         // ensure that the specified class is included
         boolean add = true;
-        for ( Class interfce : proxyObject.getClass().getInterfaces() ) {
+        for ( Class interfce : ClassUtils.getAllInterfaces(proxyObject) ) {
             if ( clazz.isAssignableFrom( interfce) ) {
                 add = false;
                 break;


### PR DESCRIPTION
This commit should not be useful, but proposing it anyway, because it
should address (IMHO) a programming error in GeoServer. This only meant
to harden things a little bit.

I suspect the code that is using reflection mechanisms to browse every
interfaces that the object respond to. But it actually only browse the
one of the final class. This is not a problem when dealing with
_InfoImpl objects, because they implement the expected interface
directly. But this is not the case for Secured_Info objects, because
they inherit from a base class (Decorating*Info) which actually
implement the expected interface.

Hence, different calls to clazz.getInterfaces() does not return the
expected interfaces. Replacing it by spring reflection helpers to get
every interfaces a proxied object should address.

Tests: runtime tested.
