### PR TITLE
WMS - fix WMS GetCapabilities 1.3.0 compliance

### DIFF
--- a/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
+++ b/src/wms/src/main/java/org/geoserver/wms/capabilities/Capabilities_1_3_0_Transformer.java
@@ -1039,7 +1039,14 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                 }
                 element("Name", defaultStyle.prefixedName());
                 if (ftStyle.getDescription() != null) {
-                    element("Title", ftStyle.getDescription().getTitle());
+                    // PMT: WMS capabilities requires at least a title,
+                    // if description's title is null, use the name
+                    // for title.
+                    if (ftStyle.getDescription().getTitle() != null) {
+                        element("Title", ftStyle.getDescription().getTitle());
+                    } else {
+                        element("Title", defaultStyle.prefixedName());
+                    }
                     element("Abstract", ftStyle.getDescription().getAbstract());
                 }
                 handleLegendURL(layer, layer.getLegend(), null, layer.getDefaultStyle());
@@ -1057,7 +1064,11 @@ public class Capabilities_1_3_0_Transformer extends TransformerBase {
                         start("Style");
                         element("Name", styleInfo.prefixedName());
                         if (ftStyle.getDescription() != null) {
-                            element("Title", ftStyle.getDescription().getTitle());
+                            if (ftStyle.getDescription().getTitle() != null) {
+                                element("Title", ftStyle.getDescription().getTitle());
+                            } else {
+                                element("Title", styleInfo.prefixedName());
+                            }
                             element("Abstract", ftStyle.getDescription().getAbstract());
                         }
                         handleLegendURL(layer, null, styleInfo, styleInfo);


### PR DESCRIPTION
Relying to the standards, (see https://github.com/highsource/jsonix/blob/master/demos/wms/src/main/resources/wms/1.3.0/capabilities_1_3_0.xsd#L522), a title is needed when describing the styles, or else it breaks the XSD.

the proposal here is to reuse the name if no title are available in the GS Java objects.

Tests:

* testsuite on WMS ok
* runtime tests directly on rennes-metropole's test instance by hardpatching the module