### PR TITLE
[geos-7946] backport, add an indirection, depending on osname, switching beetwen equals and…

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -217,7 +217,20 @@
    <dependency>
     <groupId>org.bouncycastle</groupId>
     <artifactId>bcprov-jdk14</artifactId>    
-  </dependency>
+   </dependency>
+   <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+   </dependency>
+   <dependency>
+    <groupId>org.powermock</groupId>
+    <artifactId>powermock-module-junit4</artifactId>
+   </dependency>
+   <dependency>
+    <groupId>org.powermock</groupId>
+    <artifactId>powermock-api-mockito</artifactId>
+   </dependency>
+
  </dependencies> 
 
  <build>

--- a/src/main/src/main/java/org/geoserver/data/util/IOUtils.java
+++ b/src/main/src/main/java/org/geoserver/data/util/IOUtils.java
@@ -450,12 +450,13 @@ public class IOUtils {
      * @param dest The file to rename to. 
      */
     public static void rename( File source, File dest ) throws IOException {
-        // same path? Do nothing
-        if (source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath()))
-            return;
+        boolean win = System.getProperty("os.name").startsWith("Windows");
+        boolean samePath = win ?
+                source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath()) :
+                source.getCanonicalPath().equals(dest.getCanonicalPath());
+        if (samePath) return;
 
         // windows needs special treatment, we cannot rename onto an existing file
-        boolean win = System.getProperty("os.name").startsWith("Windows");
         if ( win && dest.exists() ) {
             // windows does not do atomic renames, and can not rename a file if the dest file
             // exists

--- a/src/main/src/test/java/org/geoserver/data/util/IOUtilsTest.java
+++ b/src/main/src/test/java/org/geoserver/data/util/IOUtilsTest.java
@@ -1,0 +1,90 @@
+package org.geoserver.data.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ System.class, IOUtils.class})
+public class IOUtilsTest {
+    TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void initTmpFolder() throws IOException {
+        folder = new TemporaryFolder();
+        folder.create();
+    }
+
+    @After
+    public void deleteTmpFolder() throws IOException {
+        folder.delete();
+    }
+
+    @Test
+    public void renameDirNamesDifferLinux() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("linux");
+        String newName = "DirB";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameDirNamesCaseDifferLinux() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("linux");
+        String newName = "Dira";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+
+    @Test
+    public void renameDirNamesDifferWindows() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        String newName = "DirB";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+
+    }
+
+    @Test
+    public void renameDirNamesCaseDifferWindows() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        String oldName = "DirA";
+        String newName = "Dira";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(oldName, folder.getRoot().list()[0]);
+    }
+
+    private void attemptRename(String oldName, String newName) throws IOException {
+        File toBeRenamed = folder.newFolder(oldName);
+        assertEquals(1, folder.getRoot().list().length);
+
+        IOUtils.rename(toBeRenamed, newName);
+
+        assertEquals(1, folder.getRoot().list().length);
+    }
+
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -54,7 +54,7 @@
   <repository>
    <id>opengeo</id>
    <name>OpenGeo Maven Repository</name>
-   <url>http://repo.opengeo.org/</url>
+   <url>http://repo.boundlessgeo.com/main</url>
    <snapshots>
      <enabled>true</enabled>
    </snapshots>
@@ -564,6 +564,26 @@
     <groupId>junit</groupId>
     <artifactId>junit</artifactId>
     <version>4.11</version>
+    <scope>test</scope>
+   </dependency>
+   <dependency>
+    <groupId>org.powermock</groupId>
+    <artifactId>powermock-module-junit4</artifactId>
+    <version>${powermock.version}</version>
+    <scope>test</scope>
+   </dependency>
+   <dependency>
+    <groupId>org.powermock</groupId>
+    <artifactId>powermock-api-mockito</artifactId>
+    <version>${powermock.version}</version>
+    <scope>test</scope>
+   </dependency>
+   <!-- forcing javassist to 3.20.0-GA helps powermock mocking System.getProperty -->
+   <dependency>
+    <groupId>org.javassist</groupId>
+    <artifactId>javassist</artifactId>
+    <version>3.20.0-GA</version>
+    <scope>test</scope>
    </dependency>
    <dependency>
     <groupId>org.hamcrest</groupId>
@@ -1461,8 +1481,8 @@
 
  <properties>
   <gs.version>2.4-SNAPSHOT</gs.version>
-  <gt.version>10-SNAPSHOT</gt.version>
-  <gwc.version>1.5-SNAPSHOT</gwc.version>
+  <gt.version>10.0</gt.version>
+  <gwc.version>1.5.0</gwc.version>
   <spring.version>3.1.1.RELEASE</spring.version>
   <spring.security.version>3.1.0.RELEASE</spring.security.version> 
   <poi.version>3.8</poi.version>
@@ -1485,6 +1505,7 @@
   <javac.maxHeapSize>256m</javac.maxHeapSize>
   <image.tests>true</image.tests>
   <interactive.tests>false</interactive.tests>
+  <powermock.version>1.4.9</powermock.version>
  </properties>
 
  <profiles>


### PR DESCRIPTION
… equalsIgnoreCase in IOUtils.rename.

IOUtils.rename method does nothing when src and target names just differ depending on the case.
Such a behaviour is appropriate with windows (non case-sensitive for filename) but harms with linux, cf geos-7946.