### PR TITLE
[geos-7946] backport, add an indirection, depending on osname, switching beetwen equals and…

### DIFF
--- a/src/platform/pom.xml
+++ b/src/platform/pom.xml
@@ -67,7 +67,14 @@
   <dependency>
    <groupId>junit</groupId>
    <artifactId>junit</artifactId>
-   <scope>test</scope>
+  </dependency>
+  <dependency>
+   <groupId>org.powermock</groupId>
+   <artifactId>powermock-module-junit4</artifactId>
+  </dependency>
+  <dependency>
+   <groupId>org.powermock</groupId>
+   <artifactId>powermock-api-mockito</artifactId>
   </dependency>
   <dependency>
    <groupId>org.hamcrest</groupId>

--- a/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
+++ b/src/platform/src/main/java/org/geoserver/platform/resource/Files.java
@@ -408,13 +408,14 @@ public final class Files {
         if( dest == null ){
             throw new NullPointerException("File dest required");
         }
-        // same path? Do nothing
-        if (source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath())){
-            return true;
-        }
+
+        boolean win = System.getProperty("os.name").startsWith("Windows");
+        boolean samePath = win ?
+            source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath()) :
+            source.getCanonicalPath().equals(dest.getCanonicalPath());
+        if (samePath) return true;
 
         // windows needs special treatment, we cannot rename onto an existing file
-        boolean win = System.getProperty("os.name").startsWith("Windows");
         if ( win && dest.exists() ) {
             // windows does not do atomic renames, and can not rename a file if the dest file
             // exists
@@ -452,7 +453,7 @@ public final class Files {
      * (but not the directory itself). For each
      * file that cannot be deleted a warning log will be issued.
      * 
-     * @param dir
+     * @param directory
      * @throws IOException
      * @returns true if all the directory contents could be deleted, false otherwise
      */

--- a/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceStoreTest.java
+++ b/src/platform/src/test/java/org/geoserver/platform/resource/FileSystemResourceStoreTest.java
@@ -1,0 +1,91 @@
+package org.geoserver.platform.resource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ System.class, Files.class})
+public class FileSystemResourceStoreTest {
+
+    TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void initTmpFolder() throws IOException {
+        folder = new TemporaryFolder();
+        folder.create();
+    }
+
+    @After
+    public void deleteTmpFolder() throws IOException {
+        folder.delete();
+    }
+
+    @Test
+    public void renameDirNamesDifferLinux() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("linux");
+        String newName = "DirB";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+    @Test
+    public void renameDirNamesCaseDifferLinux() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("linux");
+        String newName = "Dira";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+    }
+
+
+    @Test
+    public void renameDirNamesDifferWindows() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        String newName = "DirB";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(newName, folder.getRoot().list()[0]);
+
+    }
+
+    @Test
+    public void renameDirNamesCaseDifferWindows() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(System.class);
+        Mockito.when(System.getProperty("os.name")).thenReturn("Windows");
+        String oldName = "DirA";
+        String newName = "Dira";
+
+        attemptRename("DirA", newName);
+
+        assertEquals(oldName, folder.getRoot().list()[0]);
+    }
+
+    private void attemptRename(String oldName, String newName) throws IOException {
+        File toBeRenamed = folder.newFolder(oldName);
+        assertEquals(1, folder.getRoot().list().length);
+        FileSystemResourceStore toTest = new FileSystemResourceStore(folder.getRoot());
+
+        toTest.move(oldName, newName);
+
+        assertEquals(1, folder.getRoot().list().length);
+    }
+}

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -616,6 +616,26 @@
     <groupId>junit</groupId>
     <artifactId>junit</artifactId>
     <version>4.11</version>
+    <scope>test</scope>
+   </dependency>
+   <dependency>
+    <groupId>org.powermock</groupId>
+    <artifactId>powermock-module-junit4</artifactId>
+    <version>${powermock.version}</version>
+    <scope>test</scope>
+   </dependency>
+   <dependency>
+    <groupId>org.powermock</groupId>
+    <artifactId>powermock-api-mockito</artifactId>
+    <version>${powermock.version}</version>
+    <scope>test</scope>
+   </dependency>
+   <!-- forcing javassist to 3.20.0-GA helps powermock mocking System.getProperty -->
+   <dependency>
+    <groupId>org.javassist</groupId>
+    <artifactId>javassist</artifactId>
+    <version>3.20.0-GA</version>
+    <scope>test</scope>
    </dependency>
    <dependency>
     <groupId>org.hamcrest</groupId>
@@ -1674,6 +1694,7 @@
   <hibernate-generic-dao-version>1.1.0</hibernate-generic-dao-version>
   <hibernate-spatial-version>1.1.1</hibernate-spatial-version>
   <hibernate-spatial-h2-version>1.1.1</hibernate-spatial-h2-version>
+  <powermock.version>1.4.9</powermock.version>
  </properties>
 
  <profiles>


### PR DESCRIPTION
… equalsIgnoreCase in Files.move and test it thru FileSystemRessourceStore.

Files.move method does nothing when src and target name just differ depending on the case.
Such a behaviour is appropriate with windows (non case-sensitive for filename) but harms with linux, cf geos-7946.