### PR TITLE
geofence - blacklisting cglib:cglib

### DIFF
--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -1286,6 +1286,13 @@
           <groupId>org.geoserver.community</groupId>
           <artifactId>gs-geofence-server</artifactId>
           <version>${project.version}</version>
+          <exclusions>
+            <!-- already provided by cglib-nodep -->
+            <exclusion>
+              <groupId>cglib</groupId>
+              <artifactId>cglib</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>              
       </dependencies>      
    </profile>


### PR DESCRIPTION
`cglib:cglib` is already provided in regular GeoServer via the artifact `cglib:cglib-nodep`. Having both version in 2 different jars leads to issues at runtime.

Problem has been encountered on the PPIGE project on the issue (not public):
https://github.com/camptocamp/georchestra-ppige-configuration/issues/374

Tests:  Compilation with `-Pgeofence-server` leads to generate an artifact without the problematic library. Untested at runtime.

