### PR TITLE
Avoid sending JSESSIONID as part of the URL

### DIFF
--- a/src/web/app/src/main/webapp/WEB-INF/web.xml
+++ b/src/web/app/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	      version="3.0">
     <display-name>GeoServer</display-name>
   
       <context-param>
@@ -266,6 +269,10 @@
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
     
+    <session-config>
+      <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+
     <mime-mapping>
       <extension>xsl</extension>
       <mime-type>text/xml</mime-type>


### PR DESCRIPTION
Fix for https://github.com/georchestra/georchestra/issues/2462, in tandem with https://github.com/georchestra/georchestra/pull/2516

Upgrade web.xml as a servlet 3.0 deployment descriptor
and add

```
<session-config>
  <tracking-mode>COOKIE</tracking-mode>
</session-config>
```

so `JSESSIONID` is sent always as a Cookie and not as part of the URL