### PR TITLE
HACK: Avoid slaves to change the updateSequence on reload

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/UpdateSequenceListener.java
+++ b/src/main/src/main/java/org/geoserver/config/UpdateSequenceListener.java
@@ -28,7 +28,7 @@ class UpdateSequenceListener implements CatalogListener, ConfigurationListener {
 
     synchronized void incrementSequence() {
         // prevent infinite loop on configuration update
-        if (updating) return;
+        if (updating || Boolean.getBoolean("geoserver.updatesequence.ignore")) return;
 
         try {
             updating = true;

--- a/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
+++ b/src/restconfig/src/main/java/org/geoserver/rest/CatalogReloadController.java
@@ -26,7 +26,12 @@ public class CatalogReloadController extends AbstractGeoServerController {
         method = {RequestMethod.POST, RequestMethod.PUT}
     )
     public void reload() throws Exception {
-        geoServer.reload();
+        System.setProperty("geoserver.updatesequence.ignore", "true");
+        try {
+            geoServer.reload();
+        }finally {
+            System.setProperty("geoserver.updatesequence.ignore", "false");
+        }
     }
 
     @RequestMapping(


### PR DESCRIPTION
Master - slave(s) set up sharing a data directory,
with an external watcher process looking for updateSequence
changes in global.xml and calling slaves' /rest/reload,
leads to a loop of configuration changes as each slave will
update the sequence upon almost every catalog change when
reloading the config.

This patch is a hack to handle that particular situation
and has not been tested on other deployment scenarios.

Fixes georchestra/georchestra/issues/2627