### PR TITLE
[GEOS-9702] Importer should not depend on ArcSDE

### DIFF
--- a/src/extension/importer/core/pom.xml
+++ b/src/extension/importer/core/pom.xml
@@ -33,10 +33,6 @@
       <artifactId>gt-jdbc-sqlserver</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.geotools</groupId>
-      <artifactId>gt-arcsde</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.geotools.xsd</groupId>
       <artifactId>gt-xsd-kml</artifactId>
       <version>${gt.version}</version>


### PR DESCRIPTION
cherrypicks geoserver/geoserver@3f0d756 to fix georchestra/georchestra#3107, targetting 2.16.1 for 20.0.x as from my understanding of georchestra/georchestra#3070 master will use 2.17.x (which has to be updated from upstream to include geoserver/geoserver#4434) - wether cherrypicking or updating to 2.16.4 is not my responsability :) 

bumping the geoserver submodule to include this left as an exercise for the release manager ;)