### PR TITLE
comment out CORS config for jetty, only one of tomcat or jetty should be enabled

### DIFF
--- a/src/web/app/src/main/webapp/WEB-INF/web.xml
+++ b/src/web/app/src/main/webapp/WEB-INF/web.xml
@@ -170,7 +170,7 @@
      -->
    </filter>
 
-   <!-- Uncomment following filter to enable CORS in Jetty. Do not forget the second config block further down.-->
+   <!-- Uncomment following filter to enable CORS in Jetty. dont forget to comment the Tomcat CORS filter config below...
     <filter>
       <filter-name>cross-origin</filter-name>
       <filter-class>org.eclipse.jetty.servlets.CrossOriginFilter</filter-class>
@@ -191,7 +191,7 @@
         <param-value>*</param-value>
       </init-param>
     </filter>
-
+   -->
    <!-- Uncomment following filter to enable CORS in Tomcat. Do not forget the second config block further down.-->
     <filter>
       <filter-name>cross-origin</filter-name>


### PR DESCRIPTION
should fix georchestra/georchestra#3358 - need submodule update for branches `master` & `20.1.x` ofc.