### PR TITLE
make sure to compile custom version of gs-geofence*

### DIFF
--- a/src/extension/geofence-server/pom.xml
+++ b/src/extension/geofence-server/pom.xml
@@ -11,6 +11,7 @@
   <groupId>org.geoserver.extension</groupId>
   <artifactId>gs-geofence-server</artifactId>
   <packaging>jar</packaging>
+  <version>2.18.3-georchestra</version>
 
   <name>GeoFence Server</name>
   <description>GeoFence security internal server</description>
@@ -167,7 +168,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${project.version}</version>
+      <version>2.18.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -203,7 +204,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wms</artifactId>
-      <version>${project.version}</version>
+      <version>2.18.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/extension/geofence/pom.xml
+++ b/src/extension/geofence/pom.xml
@@ -11,6 +11,7 @@
 
   <groupId>org.geoserver.extension</groupId>
   <artifactId>gs-geofence</artifactId>
+  <version>2.18.3-georchestra</version>
   <packaging>jar</packaging>
   <name>GeoFence security integration</name>
 
@@ -32,7 +33,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-sec-core</artifactId>
-      <version>${project.version}</version>
+      <version>2.18.3</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
@@ -58,7 +59,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${project.version}</version>
+      <version>2.18.3</version>
     </dependency>
 
     <dependency>
@@ -94,7 +95,7 @@
     <dependency>
       <groupId>org.geoserver.web</groupId>
       <artifactId>gs-web-core</artifactId>
-      <version>${project.version}</version>
+      <version>2.18.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -102,7 +103,7 @@
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-restconfig</artifactId>
-      <version>${project.version}</version>
+      <version>2.18.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/gwc/pom.xml
+++ b/src/gwc/pom.xml
@@ -15,9 +15,9 @@
 
   <groupId>org.geoserver</groupId>
   <artifactId>gs-gwc</artifactId>
+  <version>2.18.3-georchestra</version>
   <packaging>jar</packaging>
   <name>GeoWebCache (GWC) Module</name>
-  <version>2.18.3-georchestra</version>
 
   <dependencies>
     <dependency>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -16,8 +16,8 @@
 
   <groupId>org.geoserver.web</groupId>
   <artifactId>gs-web-core</artifactId>
-  <packaging>jar</packaging>
   <version>2.18.3-georchestra</version>
+  <packaging>jar</packaging>
   <name>Core UI Module</name>
 
   <dependencies>


### PR DESCRIPTION
See https://github.com/georchestra/geoserver/pull/26 ; the fix has been backported, but in the geOrchestra building process, we actually don't use the customized versions of the geofence jars. this PR aims to fix this, by suffixing the jar versions with "-georchestra" for gs-geofence & gs-geofence-server, and explicitely using them in the geoserver/webapp build from the georchestra tree.


Note: will also require a PR to the main georchestra repo (where the "...-georchestra" versions have to be explicitely set in the geoserver/webapp/pom.xml).

Tests: at compilation time, reactor build order seems OK, generated war contains the suffixed verisons:

```
$ mvn clean package -Pgeofence # into georchestra/geoserver
[...]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Main Module 2.18.3-georchestra ..................... SUCCESS [01:03 min]
[INFO] gs-restconfig 2.18.3-georchestra ................... SUCCESS [01:22 min]
[INFO] GeoWebCache (GWC) Module 2.18.3-georchestra ........ SUCCESS [01:02 min]
[INFO] Core UI Module 2.18.3-georchestra .................. SUCCESS [ 59.104 s]
[INFO] GeoFence security integration 2.18.3-georchestra ... SUCCESS [ 18.473 s]
[INFO] GeoFence Server 2.18.3-georchestra ................. SUCCESS [ 28.017 s]
[INFO] GeoServer 2.x root module 21.0-SNAPSHOT ............ SUCCESS [  4.604 s]
[INFO] geOrchestra GeoServer Web Application 21.0-SNAPSHOT  SUCCESS [ 21.113 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:39 min
[INFO] Finished at: 2021-08-16T12:50:00+02:00
[INFO] ------------------------------------------------------------------------

```
