### PR TITLE
header url - fixed missing active parameter

### DIFF
--- a/src/web/core/src/main/java/org/georchestra/GeorchestraHeaderIframe.java
+++ b/src/web/core/src/main/java/org/georchestra/GeorchestraHeaderIframe.java
@@ -30,7 +30,7 @@ public class GeorchestraHeaderIframe extends InlineFrame {
 
     @Override
     protected CharSequence getURL() {
-        return this.headerUrl;
+        return this.headerUrl + "?active=geoserver";
     }
 
     @Override


### PR DESCRIPTION
The header expects the `active` parameter to be set, see https://github.com/georchestra/georchestra/blob/9157b4ad2d53bc32ef2467128f192635c2d2d07d/header/src/main/webapp/WEB-INF/jsp/index.jsp#L311

Witnessed on customer plateform : the expected highlight on the "services" tab is missing.
![image](https://user-images.githubusercontent.com/265319/159937191-27d5fe9e-7516-4c02-bbf5-c755fdba2944.png)
