### PR TITLE
Force use of AntRun plugin 3.1.0

### DIFF
--- a/src/community/netcdf-ghrsst/pom.xml
+++ b/src/community/netcdf-ghrsst/pom.xml
@@ -72,6 +72,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>process-resources</id>

--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -443,6 +443,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>install</phase>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -2280,7 +2280,7 @@
 
           <plugin>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.7</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>read-manifest</id>

--- a/src/release/pom.xml
+++ b/src/release/pom.xml
@@ -493,6 +493,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>remove-dependencies</id>

--- a/src/web/app/pom.xml
+++ b/src/web/app/pom.xml
@@ -240,7 +240,7 @@
       <!-- Builds a valid data directory into the web app -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>configPackage</id>
@@ -269,9 +269,9 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <delete dir="${webappSourceDirectory}/data"></delete>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/src/web/core/pom.xml
+++ b/src/web/core/pom.xml
@@ -154,6 +154,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>process-resources</id>


### PR DESCRIPTION
This force the use of AntRun plugin version 3.1.0 in order at least to correct the version replacement in properties files.

It also replace a mising tasks element by target in a pom.xml