### PR TITLE
feat: set favicon to root

### DIFF
--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=10" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 	<title wicket:id="pageTitle">GeoServer</title>
-    <link href="#" rel="shortcut icon" wicket:id="faviconLink"/>
+    <link href="#" rel="shortcut icon" href="/favicon.ico"/>
 	<wicket:link>
       <link rel="stylesheet" href="css/blueprint/screen.css" type="text/css" media="screen, projection" />
       </wicket:link>

--- a/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
+++ b/src/web/core/src/main/java/org/geoserver/web/GeoServerBasePage.java
@@ -39,7 +39,6 @@ import org.apache.wicket.markup.html.panel.FeedbackPanel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
-import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.mapper.parameter.INamedParameters.Type;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -127,11 +126,13 @@ public class GeoServerBasePage extends WebPage implements IAjaxIndicatorAware {
         }
 
         // favicon
+        /* Overriding default geoserver behavior and implement georchestra root favicon
+         *  directly in html to allow custom scripts overriding more easily
         if (faviconReference == null) {
             faviconReference = new PackageResourceReference(GeoServerBasePage.class, "favicon.ico");
         }
         String faviconUrl = RequestCycle.get().urlFor(faviconReference, null).toString();
-        add(new ExternalLink("faviconLink", faviconUrl, null));
+        add(new ExternalLink("faviconLink", faviconUrl, null));*/
 
         // page title
         add(


### PR DESCRIPTION
# Favicon location

This PR is used to change favicon to point to `/favicon.ico` url.

This is supposed to be the default location for geOrchestra's favicon.

Resolving : 
- https://github.com/georchestra/georchestra/issues/4087

## Altering default behavior.

Modifying default location is not possible by now. War needs to be unzipped