### PR TITLE
Preauthentication via headers filters - Clear security context if preauth headers changed across queries

### DIFF
--- a/src/main/src/test/java/org/geoserver/security/filter/GeoServerRequestHeaderAuthenticationFilterTest.java
+++ b/src/main/src/test/java/org/geoserver/security/filter/GeoServerRequestHeaderAuthenticationFilterTest.java
@@ -1,0 +1,71 @@
+/* (c) 2023 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.security.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import javax.servlet.http.HttpServletResponse;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.security.GeoServerSecurityManager;
+import org.geoserver.security.config.PreAuthenticatedUserNameFilterConfig;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+public class GeoServerRequestHeaderAuthenticationFilterTest {
+
+    @Test
+    public void testAuthenticationViaPreAuthChanging() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        SecurityContext sc = new SecurityContextImpl();
+        sc.setAuthentication(new PreAuthenticatedAuthenticationToken("testadmin", null));
+        SecurityContextHolder.setContext(sc);
+        GeoServerRequestHeaderAuthenticationFilter toTest =
+                new GeoServerRequestHeaderAuthenticationFilter();
+        toTest.setPrincipalHeaderAttribute("sec-username");
+        request.addHeader("sec-username", "testuser");
+        toTest.setSecurityManager(
+                new GeoServerSecurityManager(new GeoServerDataDirectory(new File("/tmp"))));
+        toTest.setRoleSource(
+                PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource.Header);
+
+        toTest.doFilter(request, response, filterChain);
+
+        assertEquals(
+                "testuser",
+                SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString());
+    }
+
+    @Test
+    public void testAuthenticationViaPreAuthNoHeader() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        HttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+        SecurityContext sc = new SecurityContextImpl();
+        sc.setAuthentication(new PreAuthenticatedAuthenticationToken("testadmin", null));
+        SecurityContextHolder.setContext(sc);
+        GeoServerRequestHeaderAuthenticationFilter toTest =
+                new GeoServerRequestHeaderAuthenticationFilter();
+        toTest.setPrincipalHeaderAttribute("sec-username");
+        toTest.setSecurityManager(
+                new GeoServerSecurityManager(new GeoServerDataDirectory(new File("/tmp"))));
+        toTest.setRoleSource(
+                PreAuthenticatedUserNameFilterConfig.PreAuthenticatedUserNameRoleSource.Header);
+
+        toTest.doFilter(request, response, filterChain);
+
+        // The security context should have been cleared
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}


### PR DESCRIPTION
This is a change needed specifically when using the georchestra gateway. See https://github.com/georchestra/georchestra-gateway/issues/14 for the context.

I suspect that we don't encounter the same issue when running behind the security-proxy because in the case of the SP, the JSESSIONID are kept server-side and managed by the SP, and the security context geoserver-side is reloaded at each request depending on its value. When behind the gateway, the cookies are sent to the browser, so once we obtain a admin session, we keep it as long as we have the cookie.

In any way, clearing the context in both following cases:
* no header are sent anymore (the user disconnected from the gw)
* a preauthentication header containing the username which does not correspond to the Principal being stored in the security context
should address the issue, but I am not a security expert.

Thanks @groldan for the hints ; a similar mechanism already exists on geoserver-cloud here and was mainly the inspiration for this one:
https://github.com/geoserver/geoserver-cloud/blob/main/src/starters/security/src/main/java/org/geoserver/cloud/security/gateway/GatewayPreAuthenticationFilter.java#L42

Tests:
* UT added to test these particular cases
* Also fixed another unrelated test (see 2nd commit)
