### PR TITLE
[GEOS-11332] Renaming style with uppercase/downcase empty the sld file

### DIFF
--- a/src/platform/src/main/java/org/geoserver/util/IOUtils.java
+++ b/src/platform/src/main/java/org/geoserver/util/IOUtils.java
@@ -30,6 +30,7 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
+import org.geoserver.platform.resource.Files;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -470,7 +471,7 @@ public class IOUtils {
      */
     public static void rename(File source, File dest) throws IOException {
         // same path? Do nothing
-        if (source.getCanonicalPath().equalsIgnoreCase(dest.getCanonicalPath())) return;
+        if (source.getCanonicalPath().equals(dest.getCanonicalPath())) return;
 
         // windows needs special treatment, we cannot rename onto an existing file
         boolean win = System.getProperty("os.name").startsWith("Windows");
@@ -482,7 +483,9 @@ public class IOUtils {
             }
         }
         // make sure the rename actually succeeds
-        if (!source.renameTo(dest)) {
+        // using Files.move() instead of File.renameTo() to get better cross-platform support
+        // see also the javadoc of File.renameTo for more details
+        if (!Files.move(source, dest)) {
             FileUtils.deleteQuietly(dest);
             if (source.isDirectory()) {
                 FileUtils.moveDirectory(source, dest);

--- a/src/platform/src/test/java/org/geoserver/util/IOUtilsTest.java
+++ b/src/platform/src/test/java/org/geoserver/util/IOUtilsTest.java
@@ -70,4 +70,15 @@ public class IOUtilsTest {
             assertThat(e.getMessage(), startsWith("Entry is outside of the target directory"));
         }
     }
+
+    @Test
+    public void testRenameCaseChange() throws IOException {
+        File f = temp.newFile("foo.txt");
+        IOUtils.rename(f, "FOO.txt");
+        File renamed = new File(f.getParent(), "FOO.txt");
+
+        // file system can be case sensitive or not, so we can't really test
+        // that the old file is gone, but the new file should be there
+        assertTrue(renamed.exists());
+    }
 }


### PR DESCRIPTION
Backport upstream PR https://github.com/geoserver/geoserver/pull/7580 to georchestra's 2.25.x

Should be backported on 2.24 either https://github.com/georchestra/geoserver/pull/37


