### PR TITLE
Backport GEOS-11682

### DIFF
--- a/src/wms/pom.xml
+++ b/src/wms/pom.xml
@@ -15,6 +15,7 @@
 
   <groupId>org.geoserver</groupId>
   <artifactId>gs-wms</artifactId>
+  <version>2.25.2-georchestra</version>
   <packaging>jar</packaging>
   <name>Web Map Service Module</name>
 

--- a/src/wms/src/main/java/org/geoserver/sld/SLDXmlRequestReader.java
+++ b/src/wms/src/main/java/org/geoserver/sld/SLDXmlRequestReader.java
@@ -8,6 +8,7 @@ package org.geoserver.sld;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Map;
+import org.geoserver.catalog.StyleHandler;
 import org.geoserver.catalog.Styles;
 import org.geoserver.ows.XmlRequestReader;
 import org.geoserver.platform.ServiceException;
@@ -15,6 +16,8 @@ import org.geoserver.wms.GetMapRequest;
 import org.geoserver.wms.WMS;
 import org.geoserver.wms.map.ProcessStandaloneSLDVisitor;
 import org.geotools.api.style.StyledLayerDescriptor;
+import org.geotools.util.Version;
+import org.xml.sax.EntityResolver;
 
 /**
  * Reads
@@ -37,9 +40,15 @@ public class SLDXmlRequestReader extends XmlRequestReader {
         }
         try {
             GetMapRequest getMap = (GetMapRequest) request;
+            String styleFormat = getMap.getStyleFormat();
+            StyleHandler styleParser = Styles.handler(styleFormat);
+
+            Version styleVersion = getMap.styleVersion();
+
+            EntityResolver entityResolver = wms.getCatalog().getResourcePool().getEntityResolver();
+
             StyledLayerDescriptor sld =
-                    Styles.handler(getMap.getStyleFormat())
-                            .parse(reader, getMap.styleVersion(), null, null);
+                    styleParser.parse(reader, styleVersion, null, entityResolver);
 
             // process the sld
             sld.accept(new ProcessStandaloneSLDVisitor(wms, getMap));

--- a/src/wms/src/test/java/org/geoserver/sld/SLDXmlRequestReaderTest.java
+++ b/src/wms/src/test/java/org/geoserver/sld/SLDXmlRequestReaderTest.java
@@ -1,0 +1,72 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.sld;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import org.geoserver.ows.XmlRequestReader;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geoserver.wms.WMSTestSupport;
+import org.geotools.util.logging.Logging;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Test suite for {@link SLDXmlRequestReader} */
+public class SLDXmlRequestReaderTest extends WMSTestSupport {
+
+    @Test
+    public void testExtensionPoint() {
+        List<XmlRequestReader> xmlReaders = GeoServerExtensions.extensions(XmlRequestReader.class);
+        Optional<SLDXmlRequestReader> findExtension =
+                xmlReaders.stream()
+                        .filter(SLDXmlRequestReader.class::isInstance)
+                        .map(SLDXmlRequestReader.class::cast)
+                        .findFirst();
+        assertTrue(findExtension.isPresent());
+    }
+
+    @Test
+    public void testGetMapSld() throws Exception {
+        String path =
+                "/wms?service=WMS&version=1.1.0&request=GetMap&width=100&height=100&format=image/png&bbox=-180,-90,180,90";
+        String body =
+                "    <StyledLayerDescriptor version=\"1.0.0\">\n"
+                        + "        <NamedLayer>\n"
+                        + "            <Name>wcs:World</Name>\n"
+                        + "            <NamedStyle><Name>generic</Name></NamedStyle>\n"
+                        + "        </NamedLayer>\n"
+                        + "    </StyledLayerDescriptor>\n";
+        MockHttpServletResponse response = super.postAsServletResponse(path, body);
+        assertEquals(200, response.getStatus());
+        assertEquals("image/png", response.getContentType());
+    }
+
+    @Test
+    public void testGetMapSldXXE() throws Exception {
+        String path =
+                "/wms?service=WMS&version=1.1.0&request=GetMap&width=100&height=100&format=image/png&bbox=-180,-90,180,90";
+        String body =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                        + "<!DOCTYPE StyledLayerDescriptor [\n"
+                        + "<!ENTITY xxe SYSTEM \"file:///some/file\">]>\n"
+                        + "<StyledLayerDescriptor version=\"1.0.0\">\n"
+                        + "<NamedLayer><Name>&xxe;</Name></NamedLayer>\n"
+                        + "</StyledLayerDescriptor>";
+
+        Logging.getLogger("geoserver.ows").setLevel(Level.OFF);
+        MockHttpServletResponse response = super.postAsServletResponse(path, body);
+        assertEquals(200, response.getStatus());
+        super.assertContentType("application/vnd.ogc.se_xml", response);
+        assertThat(
+                response.getContentAsString(),
+                containsString("Entity resolution disallowed for file"));
+    }
+}


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

see https://osgeo-org.atlassian.net/browse/GEOS-11682 for the motivation.

Note: this would require to explicitely use org.geoserver:gs-wms:2.25.2-georchestra in the webapp's pom.xml of the geOrchestra geoserver webapp.

This is only needed for 2.25.x geOrchestra's geoserver serie. 2.26.2 is (about to be) patched with https://github.com/georchestra/georchestra/pull/4390