### PR TITLE
fix: fixing ogcapi / wfs getfeatures incompatibility

### DIFF
--- a/src/extension/ogcapi/ogcapi-features/pom.xml
+++ b/src/extension/ogcapi/ogcapi-features/pom.xml
@@ -15,36 +15,37 @@
 
   <groupId>org.geoserver.extension</groupId>
   <artifactId>gs-ogcapi-features</artifactId>
+  <version>2.28.0-georchestra</version>
 
   <dependencies>
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-ows</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-main</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.geoserver</groupId>
       <artifactId>gs-wfs</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -67,7 +68,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-ogcapi-core</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -85,7 +86,7 @@
     <dependency>
       <groupId>org.geoserver.extension</groupId>
       <artifactId>gs-app-schema-test</artifactId>
-      <version>${project.version}</version>
+      <version>${project.parent.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/RFCGeoJSONFeaturesResponse.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/RFCGeoJSONFeaturesResponse.java
@@ -226,7 +226,8 @@ public class RFCGeoJSONFeaturesResponse extends GeoJSONGetFeatureResponse {
                 || "GetFeatureWithLock".equalsIgnoreCase(operationId)
                 || "getTile".equalsIgnoreCase(operationId)) {
             return operation.getService() != null
-                    && "Features".equals(operation.getService().getId());
+                            && "Features".equals(operation.getService().getId())
+                    || "WFS".equalsIgnoreCase(operation.getService().getId());
         }
         return false;
     }

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -1093,7 +1093,7 @@
         <dependency>
           <groupId>org.geoserver.extension</groupId>
           <artifactId>gs-ogcapi-features</artifactId>
-          <version>${gs.version}</version>
+          <version>${gs.version}-georchestra</version>
         </dependency>
         <dependency>
           <groupId>org.geoserver.extension</groupId>


### PR DESCRIPTION
See https://osgeo-org.atlassian.net/browse/GEOS-11926 for the motivation.

Runtime tested on a osgeo 2.28.x docker image, the GetFeature suggestedin the ticket works fine afterwards, would deserve more thorough tests before considering merging.
