### PR TITLE
Remove GEOSERVER_FILESYSTEM_SANDBOX environment variable and set it as Java properties.

### DIFF
--- a/webapp/src/docker/Dockerfile
+++ b/webapp/src/docker/Dockerfile
@@ -33,7 +33,6 @@ VOLUME [ "/mnt/geoserver_datadir", "/mnt/geoserver_geodata", "/mnt/geoserver_til
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
 ENV LD_LIBRARY_PATH=/mnt/geoserver_native_libs:/opt/libjpeg-turbo/lib64
-ENV GEOSERVER_FILESYSTEM_SANDBOX=/mnt/
 
 CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
 -Dgeofence-ovr=file:/etc/georchestra/geoserver/geofence/geofence-datasource-ovr.properties \
@@ -42,6 +41,7 @@ CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
 -DGEOSERVER_DATA_DIR=/mnt/geoserver_datadir \
 -DGEOWEBCACHE_CACHE_DIR=/mnt/geoserver_tiles \
 -DGEOWEBCACHE_CONFIG_DIR=/mnt/geoserver_datadir/gwc \
+-DGEOSERVER_FILESYSTEM_SANDBOX=/mnt/ \
 -Dhttps.protocols=TLSv1.2,TLSv1.3 \
 -XX:MaxRAMPercentage=80 -XX:+UseParallelGC \
 -XX:SoftRefLRUPolicyMSPerMB=36000 \


### PR DESCRIPTION
It allows to override CMD from initial Dockerfile and use regular sandbox https://docs.geoserver.org/latest/en/user/security/sandbox/?h=sandbox

Exemple of dockerfile to remove GEOSERVER_FILESYSTEM_SANDBOX property: 

```Dockerfile
FROM georchestra/geoserver:<version>

CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty \
-Dgeofence-ovr=file:/etc/georchestra/geoserver/geofence/geofence-datasource-ovr.properties \
-Dgwc.context.suffix=gwc \
-Dgeorchestra.datadir=/etc/georchestra \
-DGEOSERVER_DATA_DIR=/mnt/geoserver_datadir \
-DGEOWEBCACHE_CACHE_DIR=/mnt/geoserver_tiles \
-DGEOWEBCACHE_CONFIG_DIR=/mnt/geoserver_datadir/gwc \
-Dhttps.protocols=TLSv1.2,TLSv1.3 \
-XX:MaxRAMPercentage=80 -XX:+UseParallelGC \
-XX:SoftRefLRUPolicyMSPerMB=36000 \
-XX:-UsePerfData \
${JAVA_OPTIONS} \
-Djetty.httpConfig.sendServerVersion=false \
-Djetty.jmxremote.rmiregistryhost=${JMX_HOST:-127.0.0.1} \
-Djetty.jmxremote.rmiserverhost=${JMX_HOST:-127.0.0.1} \
-Dcom.sun.management.jmxremote=${JMX_ENABLE:-false} \
-Dcom.sun.management.jmxremote.host=${JMX_HOST:-127.0.0.1} \
-Dcom.sun.management.jmxremote.ssl=${JMX_SSL:-false} \
-Dcom.sun.management.jmxremote.authenticate=${JMX_AUTHENTICATE:-false} \
-jar /usr/local/jetty/start.jar" ]
```