### PR TITLE
fix: ogcapi-features - fix JSONFGFeaturesResponse in case of non-geo datasets

### DIFF
--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeaturesResponse.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeaturesResponse.java
@@ -80,6 +80,7 @@ public class JSONFGFeaturesResponse extends RFCGeoJSONFeaturesResponse {
     }
 
     private String getCRSURI(CoordinateReferenceSystem crs) {
+        if (crs == null) return null;
         try {
             // prefer EPSG authority if possible, more commonly understood
             String epsgIdentifier = CRS.lookupIdentifier(Citations.EPSG, crs, false);


### PR DESCRIPTION
When the output format is requested on a non-geographical dataset, GS fails with a NPE while trying to resolve the CRS, because crs object is null.

Fixing the behaviour by trivially adding a if guard to check the nullity of the object. The GeoJSON spec states that having a null JSON object for the geometry is ok, so the fix sounds good to me.

Tests: runtime tested