### PR TITLE
fix: ogcapi-features - fix JSONFGFeaturesResponse in case of non-geo datasets

### DIFF
--- a/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeaturesResponse.java
+++ b/src/extension/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/JSONFGFeaturesResponse.java
@@ -80,6 +80,7 @@ public class JSONFGFeaturesResponse extends RFCGeoJSONFeaturesResponse {
     }
 
     private String getCRSURI(CoordinateReferenceSystem crs) {
+        if (crs == null) return null;
         try {
             // prefer EPSG authority if possible, more commonly understood
             String epsgIdentifier = CRS.lookupIdentifier(Citations.EPSG, crs, false);


### PR DESCRIPTION
See https://github.com/georchestra/geoserver/pull/51 ("ported forward" ~ I mean the opposite of "backported")

Tests: runtime tested